### PR TITLE
Add retry mechanism for API calls

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,102 @@
+import logger from '../logger';
+
+/**
+ * Configuration options for the retry mechanism
+ */
+export interface RetryOptions {
+  /** Maximum number of retry attempts */
+  maxRetries: number;
+  /** Initial delay between retries in milliseconds */
+  initialDelay: number;
+  /** Multiplier to increase delay on each retry */
+  backoffFactor: number;
+  /** Optional function to determine if error is retriable */
+  isRetriable?: (error: any) => boolean;
+}
+
+const defaultRetryOptions: RetryOptions = {
+  maxRetries: 3,
+  initialDelay: 1000,
+  backoffFactor: 2,
+  isRetriable: () => true
+};
+
+/**
+ * Sleep for the specified duration
+ * @param ms Time to sleep in milliseconds
+ */
+const sleep = (ms: number): Promise<void> => 
+  new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Wraps an async function with retry logic
+ * @param fn The function to retry
+ * @param options Retry configuration options
+ * @returns A function that will retry on failure
+ */
+export const withRetry = <T, Args extends any[]>(
+  fn: (...args: Args) => Promise<T>,
+  options: Partial<RetryOptions> = {}
+): ((...args: Args) => Promise<T>) => {
+  const config = { ...defaultRetryOptions, ...options };
+  
+  return async (...args: Args): Promise<T> => {
+    let lastError: any;
+    let delay = config.initialDelay;
+    
+    for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+      try {
+        if (attempt > 0) {
+          logger.info(`Retry attempt ${attempt}/${config.maxRetries}`, {
+            functionName: fn.name,
+            delay
+          });
+        }
+        
+        return await fn(...args);
+      } catch (error) {
+        lastError = error;
+        
+        const isRetriable = config.isRetriable?.(error);
+        const hasAttemptsLeft = attempt < config.maxRetries;
+        
+        if (!isRetriable || !hasAttemptsLeft) {
+          logger.error(`Error in ${fn.name}, no more retries`, {
+            error,
+            attempt,
+            maxRetries: config.maxRetries
+          });
+          break;
+        }
+        
+        logger.warn(`Temporary error in ${fn.name}, will retry`, {
+          error: error instanceof Error ? error.message : error,
+          attempt,
+          nextDelay: delay
+        });
+        
+        await sleep(delay);
+        delay *= config.backoffFactor;
+      }
+    }
+    
+    throw lastError;
+  };
+};
+
+/**
+ * Example usage:
+ * 
+ * // For API calls that might fail due to rate limiting
+ * const callAnthropicWithRetry = withRetry(
+ *   anthropicClient.logAndCreateChatCompletion.bind(anthropicClient),
+ *   {
+ *     maxRetries: 5,
+ *     initialDelay: 2000,
+ *     isRetriable: (error) => {
+ *       // Retry on rate limit errors or network issues
+ *       return error.status === 429 || error.code === 'ECONNRESET';
+ *     }
+ *   }
+ * );
+ */

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the retry utility
+ * 
+ * To run:
+ * bun test test/utils/retry.test.ts
+ */
+
+import { describe, expect, it, jest, beforeEach } from 'bun:test';
+import { withRetry } from '../../src/utils/retry';
+
+// Mock the logger to avoid console output during tests
+jest.mock('../../src/logger', () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }
+}));
+
+describe('retry utility', () => {
+  // Avoid real delays in tests
+  beforeEach(() => {
+    global.setTimeout = jest.fn((callback) => {
+      callback();
+      return 0 as any;
+    });
+  });
+
+  it('should return the result if the function succeeds on first try', async () => {
+    // Arrange
+    const mockFn = jest.fn().mockResolvedValue('success');
+    const retryFn = withRetry(mockFn, { maxRetries: 3 });
+    
+    // Act
+    const result = await retryFn('arg1', 'arg2');
+    
+    // Assert
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledWith('arg1', 'arg2');
+  });
+
+  it('should retry when function fails and then succeed', async () => {
+    // Arrange
+    const mockFn = jest.fn()
+      .mockRejectedValueOnce(new Error('Temporary error'))
+      .mockResolvedValueOnce('success after retry');
+    
+    const retryFn = withRetry(mockFn, { maxRetries: 3, initialDelay: 100 });
+    
+    // Act
+    const result = await retryFn();
+    
+    // Assert
+    expect(result).toBe('success after retry');
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw after exhausting all retries', async () => {
+    // Arrange
+    const error = new Error('Persistent error');
+    const mockFn = jest.fn().mockRejectedValue(error);
+    const retryFn = withRetry(mockFn, { maxRetries: 2, initialDelay: 100 });
+    
+    // Act & Assert
+    await expect(retryFn()).rejects.toThrow(error);
+    expect(mockFn).toHaveBeenCalledTimes(3); // Initial + 2 retries
+  });
+
+  it('should not retry if isRetriable returns false', async () => {
+    // Arrange
+    const error = new Error('Non-retriable error');
+    const mockFn = jest.fn().mockRejectedValue(error);
+    const isRetriable = jest.fn().mockReturnValue(false);
+    
+    const retryFn = withRetry(mockFn, { 
+      maxRetries: 3, 
+      initialDelay: 100,
+      isRetriable
+    });
+    
+    // Act & Assert
+    await expect(retryFn()).rejects.toThrow(error);
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(isRetriable).toHaveBeenCalledTimes(1);
+    expect(isRetriable).toHaveBeenCalledWith(error);
+  });
+
+  it('should apply backoff factor to delays', async () => {
+    // Arrange - Restore setTimeout to track delay values
+    const mockSetTimeout = jest.fn((callback, ms) => {
+      callback();
+      return 0 as any;
+    });
+    global.setTimeout = mockSetTimeout;
+    
+    const mockFn = jest.fn()
+      .mockRejectedValueOnce(new Error('Error 1'))
+      .mockRejectedValueOnce(new Error('Error 2'))
+      .mockResolvedValueOnce('success');
+    
+    const retryFn = withRetry(mockFn, { 
+      maxRetries: 2, 
+      initialDelay: 1000,
+      backoffFactor: 2
+    });
+    
+    // Act
+    await retryFn();
+    
+    // Assert
+    expect(mockSetTimeout).toHaveBeenCalledTimes(2);
+    expect(mockSetTimeout.mock.calls[0][1]).toBe(1000); // First retry
+    expect(mockSetTimeout.mock.calls[1][1]).toBe(2000); // Second retry (1000 * 2)
+  });
+});


### PR DESCRIPTION
Closes #3

This PR implements a robust retry mechanism for API calls to improve reliability when interacting with external services like the Anthropic API. It includes:

- A `withRetry` utility function that wraps async operations with configurable retry logic
- Exponential backoff for retries to reduce load during outages
- Configurable retry policies (max attempts, delays, retry conditions)
- Unit tests to verify the retry mechanism works correctly

### Usage Example

```typescript
// In anthropic.ts
import { withRetry } from './utils/retry';

// Create a retry-enabled version of the API call
const callAnthropicWithRetry = withRetry(
  client.logAndCreateChatCompletion.bind(client),
  {
    maxRetries: 3,
    initialDelay: 1000,
    backoffFactor: 2,
    isRetriable: (error) => {
      // Retry on rate limit errors or network issues
      return error.status === 429 || error.code === 'ECONNRESET';
    }
  }
);

// Use the retry-enabled function instead of the regular API call
const result = await callAnthropicWithRetry(params);
```

This enhancement will make the bot more resilient to temporary network issues, rate limits, and other transient API errors.